### PR TITLE
Type coercion for figura containers

### DIFF
--- a/figura/container.py
+++ b/figura/container.py
@@ -4,7 +4,7 @@ Definition of the config-container type.
 
 import json
 
-from .misc import Struct, merge_dicts, deep_getattr, deep_setattr
+from .misc import Struct, merge_dicts, deep_getattr, deep_setattr, coerce_type
 
 
 ################################################################################
@@ -39,6 +39,12 @@ class ConfigContainerMixin():
 
         .. _deep_setattr:
         """
+        try:
+            current_value = deep_getattr(self, attr_path)
+            value = coerce_type(current_value, value)
+        except AttributeError:
+            pass
+
         return deep_setattr(self, attr_path, value)
 
     def apply_overrides(self, overrides, **kwargs):

--- a/figura/misc.py
+++ b/figura/misc.py
@@ -79,6 +79,29 @@ class Struct(dict):
 ################################################################################
 # attribute access tricks
 
+_BOOLEAN_VALUES = {
+    '0': False, '1': True,
+    'no': False, 'yes': True,
+    'n': False, 'y': True,
+    'false': False, 'true': True,
+    'disabled': False, 'enabled': True,
+    'off': False, 'on': True,
+}
+
+def coerce_type(original_value, new_value):
+    # don't coerce non-string values
+    if not isinstance(new_value, basestring):
+        return new_value
+
+    if isinstance(original_value, bool):
+        boolean_value = _BOOLEAN_VALUES.get(new_value.lower())
+        if boolean_value is not None:
+            return boolean_value
+    elif isinstance(original_value, (int, float)):
+        return type(original_value)(new_value)
+
+    return new_value
+
 def deep_getattr(x, attr_path, *args, **kwargs):
     """
     ``deep_getattr(x, 'a.b.c')`` -->

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -1,0 +1,60 @@
+import unittest
+
+import figura
+
+class TestConfigContainer(unittest.TestCase):
+    def setUp(self):
+        self.config = figura.ConfigContainer.from_dict(dict(foo=dict(bar=dict())))
+
+    def test__coerce_type(self):
+        new_value = figura.misc.coerce_type(1, "2")
+        self.assertEqual(new_value, 2)
+
+    def test_deep_setting(self):
+        self.config.deep_setattr('foo.bar.baz', 1)
+        self.assertEqual(self.config.deep_getattr('foo.bar.baz'), 1)
+        self.assertEqual(self.config.foo.bar.baz, 1)
+
+    def test_type_coercing(self):
+        # int
+        self.config.deep_setattr('int', 1)
+        self.assertEqual(self.config.deep_getattr('int'), 1)
+        self.config.deep_setattr('int', "2")
+        self.assertEqual(self.config.deep_getattr('int'), 2)
+
+        # float
+        self.config.deep_setattr('float', 1.2)
+        self.assertEqual(self.config.deep_getattr('float'), 1.2)
+        self.config.deep_setattr('float', "2.3")
+        self.assertEqual(self.config.deep_getattr('float'), 2.3)
+
+        # bool
+        self.config.deep_setattr('bool', False)
+        self.assertEqual(self.config.deep_getattr('bool'), False)
+        self.config.deep_setattr('bool', "True")
+        self.assertEqual(self.config.deep_getattr('bool'), True)
+
+        # list
+        self.config.deep_setattr('list', [])
+        self.assertEqual(self.config.deep_getattr('list'), [])
+        self.config.deep_setattr('list', '1@,2')
+        self.assertEqual(self.config.deep_getattr('list'), '1@,2')
+
+        # string
+        self.config.deep_setattr('string', 'foobarbaz')
+        self.assertEqual(self.config.deep_getattr('string'), 'foobarbaz')
+        self.config.deep_setattr('string', 'bazbarquux')
+        self.assertEqual(self.config.deep_getattr('string'), 'bazbarquux')
+
+        # arbitrary objects
+        class Foo(object):
+            pass
+        o = Foo()
+        self.config.deep_setattr('arbitrary_object', o)
+        self.assertEqual(self.config.deep_getattr('arbitrary_object'), o)
+        self.config.deep_setattr('arbitrary_object', "foobar")
+        self.assertEqual(self.config.deep_getattr('arbitrary_object'), "foobar")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This simplifies use of command line overrides, since they will assume the correct types inside the figura container.

Perhaps more importantly is that client code can safely assume the correct types are already set.